### PR TITLE
Include catkin directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
 include_directories(
   ${RPLIDAR_SDK_PATH}/include
   ${RPLIDAR_SDK_PATH}/src
+  ${catkin_INCLUDE_DIRS}
 )
 
 catkin_package()


### PR DESCRIPTION
Without this, it won't build without sourcing setup.bash first.
Note that this will mean it fails the first time you try to release
it as a deb on the osrf build farm as it is a sandboxed environment.