### PR TITLE
Reverse the scan publisher if max < min.

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -67,8 +67,8 @@ void publish_scan(ros::Publisher *pub,
     scan_msg.header.frame_id = frame_id;
     scan_count++;
 
-    bool reverse = (angle_max > angle_min);
-    if ( reverse ) {
+    bool reversed = (angle_max > angle_min);
+    if ( reversed ) {
       scan_msg.angle_min =  M_PI - angle_max;
       scan_msg.angle_max =  M_PI - angle_min;
     } else {
@@ -86,7 +86,8 @@ void publish_scan(ros::Publisher *pub,
 
     scan_msg.intensities.resize(node_count);
     scan_msg.ranges.resize(node_count);
-    if (!inverted) { // assumes scan window at the top
+    bool reverse_data = (!inverted && reversed) || (inverted && !reversed);
+    if (!reverse_data) {
         for (size_t i = 0; i < node_count; i++) {
             float read_value = (float) nodes[i].distance_q2/4.0f/1000;
             if (read_value == 0.0)
@@ -104,10 +105,6 @@ void publish_scan(ros::Publisher *pub,
                 scan_msg.ranges[node_count-1-i] = read_value;
             scan_msg.intensities[node_count-1-i] = (float) (nodes[i].sync_quality >> 2);
         }
-    }
-    if ( reverse ) {
-      std::reverse(scan_msg.ranges.begin(), scan_msg.ranges.end());
-      std::reverse(scan_msg.intensities.begin(), scan_msg.intensities.end());
     }
 
     pub->publish(scan_msg);


### PR DESCRIPTION
Common convention for ros laser scanners is that angle_min < angle_max in the published scan message. RPLidar doesn't do this, and that makes it inconvenient when wishing to swap it out for a simulated stage/gazebo laser.

This reverses the scan data and the min/max if they happen to be reversed.

This does add a cost to publishing though, so it might be worth enabling a parameter to make this optional.