### PR TITLE
solving linking issue:  CMakeFiles/rplidarNode.dir/sdk/src/arch/linux/timer.cpp.o: undefined reference to symbol 'clock_gettime@@GLIBC_2.4'  in rpi2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
 catkin_package()
 
 add_executable(rplidarNode src/node.cpp ${RPLIDAR_SDK_SRC})
-target_link_libraries(rplidarNode ${catkin_LIBRARIES})
+target_link_libraries(rplidarNode rt ${catkin_LIBRARIES})
 
 add_executable(rplidarNodeClient src/client.cpp)
 target_link_libraries(rplidarNodeClient ${catkin_LIBRARIES})


### PR DESCRIPTION
There is a linking error for this code on rpi2 and in theory may appear in other ARM-based systems. It is solved in this pull request.