### PR TITLE
set drv to NULL on dispose

### DIFF
--- a/sdk/include/rplidar_driver.h
+++ b/sdk/include/rplidar_driver.h
@@ -8,26 +8,26 @@
  *
  */
 /*
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, 
+ * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
@@ -54,7 +54,7 @@ public:
     /// Create an RPLIDAR Driver Instance
     /// This interface should be invoked first before any other operations
     ///
-    /// \param drivertype the connection type used by the driver. 
+    /// \param drivertype the connection type used by the driver.
     static RPlidarDriver * CreateDriver(_u32 drivertype = DRIVER_TYPE_SERIALPORT);
 
     /// Dispose the RPLIDAR Driver Instance specified by the drv parameter
@@ -65,8 +65,8 @@ public:
 public:
     /// Open the specified serial port and connect to a target RPLIDAR device
     ///
-    /// \param port_path     the device path of the serial port 
-    ///        e.g. on Windows, it may be com3 or \\.\com10 
+    /// \param port_path     the device path of the serial port
+    ///        e.g. on Windows, it may be com3 or \\.\com10
     ///             on Unix-Like OS, it may be /dev/ttyS1, /dev/ttyUSB2, etc
     ///
     /// \param baudrate      the baudrate used
@@ -86,7 +86,7 @@ public:
     /// Ask the RPLIDAR core system to reset it self
     /// The host system can use the Reset operation to help RPLIDAR escape the self-protection mode.
     ///
-    //  \param timeout       The operation timeout value (in millisecond) for the serial port communication                     
+    //  \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result reset(_u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Retrieve the health status of the RPLIDAR
@@ -94,26 +94,26 @@ public:
     ///
     /// \param health        The health status info returned from the RPLIDAR
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication     
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result getHealth(rplidar_response_device_health_t & health, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Get the device information of the RPLIDAR include the serial number, firmware version, device model etc.
-    /// 
+    ///
     /// \param info          The device information returned from the RPLIDAR
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication  
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result getDeviceInfo(rplidar_response_device_info_t & info, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Get the sample duration information of the RPLIDAR.
-    /// 
+    ///
     /// \param rateInfo      The sample duration information returned from the RPLIDAR
     ///
     /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result getSampleDuration_uS(rplidar_response_sample_rate_t & rateInfo, _u32 timeout = DEFAULT_TIMEOUT) = 0;
-    
+
     /// Set the RPLIDAR's motor pwm when using accessory board, currently valid for A2 only.
-    /// 
-    /// \param pwm           The motor pwm value would like to set 
+    ///
+    /// \param pwm           The motor pwm value would like to set
     virtual u_result setMotorPWM(_u16 pwm) = 0;
 
     /// Start RPLIDAR's motor when using accessory board
@@ -124,10 +124,10 @@ public:
 
     /// Check whether the device support motor control.
     /// Note: this API will disable grab.
-    /// 
+    ///
     /// \param support       Return the result.
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication. 
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication.
     virtual u_result checkMotorCtrlSupport(bool & support, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Calcuate RPLIDAR's current scanning frequency from the given scan data
@@ -157,7 +157,7 @@ public:
     virtual u_result startScanExpress(bool fixedAngle, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Check whether the device support express mode.
-    /// 
+    ///
     /// \param support       Return the result.
     ///
     /// \param timeout       The operation timeout value (in millisecond) for the serial port communication.
@@ -165,11 +165,11 @@ public:
 
     /// Ask the RPLIDAR core system to stop the current scan operation and enter idle state. The background thread will be terminated
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication 
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result stop(_u32 timeout = DEFAULT_TIMEOUT) = 0;
 
 
-    /// Wait and grab a complete 0-360 degree scan data previously received. 
+    /// Wait and grab a complete 0-360 degree scan data previously received.
     /// The grabbed scan data returned by this interface always has the following charactistics:
     ///
     /// 1) The first node of the grabbed data array (nodebuffer[0]) must be the first sample of a scan, i.e. the start_bit == 1
@@ -183,7 +183,7 @@ public:
     ///
     /// \param timeout        Max duration allowed to wait for a complete scan data, nothing will be stored to the nodebuffer if a complete 360-degrees' scan data cannot to be ready timely.
     ///
-    /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that no complete 360-degrees' scan can be retrieved withing the given timeout duration. 
+    /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that no complete 360-degrees' scan can be retrieved withing the given timeout duration.
     ///
     /// \The caller application can set the timeout value to Zero(0) to make this interface always returns immediately to achieve non-block operation.
 	virtual u_result grabScanData(rplidar_response_measurement_node_t * nodebuffer, size_t & count, _u32 timeout = DEFAULT_TIMEOUT) = 0;
@@ -194,7 +194,7 @@ public:
     ///
     /// \param count          The caller must initialize this parameter to set the max data count of the provided buffer (in unit of rplidar_response_measurement_node_t).
     ///                       Once the interface returns, this parameter will store the actual received data count.
-    /// The interface will return RESULT_OPERATION_FAIL when all the scan data is invalid. 
+    /// The interface will return RESULT_OPERATION_FAIL when all the scan data is invalid.
     virtual u_result ascendScanData(rplidar_response_measurement_node_t * nodebuffer, size_t count) = 0;
 
 protected:

--- a/sdk/include/rplidar_driver.h
+++ b/sdk/include/rplidar_driver.h
@@ -59,7 +59,7 @@ public:
 
     /// Dispose the RPLIDAR Driver Instance specified by the drv parameter
     /// Applications should invoke this interface when the driver instance is no longer used in order to free memory
-    static void DisposeDriver(RPlidarDriver * drv);
+    static void DisposeDriver(RPlidarDriver ** drv);
 
 
 public:

--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -8,26 +8,26 @@
  *
  */
 /*
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, 
+ * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
@@ -61,13 +61,14 @@ RPlidarDriver * RPlidarDriver::CreateDriver(_u32 drivertype)
 void RPlidarDriver::DisposeDriver(RPlidarDriver * drv)
 {
     delete drv;
+    drv = NULL;
 }
 
 
 
 // Serial Driver Impl
 
-RPlidarDriverSerialImpl::RPlidarDriverSerialImpl() 
+RPlidarDriverSerialImpl::RPlidarDriverSerialImpl()
     : _isConnected(false)
     , _isScanning(false)
     , _isSupportingMotorCtrl(false)
@@ -141,9 +142,9 @@ u_result RPlidarDriverSerialImpl::reset(_u32 timeout)
 u_result RPlidarDriverSerialImpl::getHealth(rplidar_response_device_health_t & healthinfo, _u32 timeout)
 {
     u_result  ans;
-    
+
     if (!isConnected()) return RESULT_OPERATION_FAIL;
-    
+
     _disableDataGrabbing();
 
     {
@@ -179,7 +180,7 @@ u_result RPlidarDriverSerialImpl::getHealth(rplidar_response_device_health_t & h
 u_result RPlidarDriverSerialImpl::getDeviceInfo(rplidar_response_device_info_t & info, _u32 timeout)
 {
     u_result  ans;
-    
+
     if (!isConnected()) return RESULT_OPERATION_FAIL;
 
     _disableDataGrabbing();
@@ -343,7 +344,7 @@ u_result RPlidarDriverSerialImpl::startScan(bool force, bool autoExpressMode)
         ans = checkExpressScanSupported(isExpressModeSupported);
 
         if (IS_FAIL(ans)) return ans;
-    
+
         if (isExpressModeSupported) {
             return startScanExpress(false);
         }
@@ -392,8 +393,8 @@ u_result RPlidarDriverSerialImpl::_cacheScanData()
         {
             if (local_buf[pos].sync_quality & RPLIDAR_RESP_MEASUREMENT_SYNCBIT)
             {
-                // only publish the data when it contains a full 360 degree scan 
-                
+                // only publish the data when it contains a full 360 degree scan
+
                 if ((local_scan[0].sync_quality & RPLIDAR_RESP_MEASUREMENT_SYNCBIT)) {
                     _lock.lock();
                     memcpy(_cached_scan_node_buf, local_scan, scan_count*sizeof(rplidar_response_measurement_node_t));
@@ -501,8 +502,8 @@ u_result RPlidarDriverSerialImpl::_cacheCapsuledScanData()
         {
             if (local_buf[pos].sync_quality & RPLIDAR_RESP_MEASUREMENT_SYNCBIT)
             {
-                // only publish the data when it contains a full 360 degree scan 
-                
+                // only publish the data when it contains a full 360 degree scan
+
                 if ((local_scan[0].sync_quality & RPLIDAR_RESP_MEASUREMENT_SYNCBIT)) {
                     _lock.lock();
                     memcpy(_cached_scan_node_buf, local_scan, scan_count*sizeof(rplidar_response_measurement_node_t));
@@ -626,13 +627,13 @@ u_result RPlidarDriverSerialImpl::_waitNode(rplidar_response_measurement_node_t 
         size_t recvSize;
 
         int ans = _rxtx->waitfordata(remainSize, timeout-waitTime, &recvSize);
-        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR) 
+        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR)
             return RESULT_OPERATION_FAIL;
         else if (ans == rp::hal::serial_rxtx::ANS_TIMEOUT)
             return RESULT_OPERATION_TIMEOUT;
 
         if (recvSize > remainSize) recvSize = remainSize;
-        
+
         _rxtx->recvdata(recvBuffer, recvSize);
 
         for (size_t pos = 0; pos < recvSize; ++pos) {
@@ -689,7 +690,7 @@ u_result RPlidarDriverSerialImpl::_waitScanData(rplidar_response_measurement_nod
         if (IS_FAIL(ans = _waitNode(&node, timeout - waitTime))) {
             return ans;
         }
-        
+
         nodebuffer[recvNodeCount++] = node;
 
         if (recvNodeCount == count) return RESULT_OK;
@@ -712,13 +713,13 @@ u_result RPlidarDriverSerialImpl::_waitCapsuledNode(rplidar_response_capsule_mea
         size_t recvSize;
 
         int ans = _rxtx->waitfordata(remainSize, timeout-waitTime, &recvSize);
-        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR) 
+        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR)
             return RESULT_OPERATION_FAIL;
         else if (ans == rp::hal::serial_rxtx::ANS_TIMEOUT)
             return RESULT_OPERATION_TIMEOUT;
 
         if (recvSize > remainSize) recvSize = remainSize;
-        
+
         _rxtx->recvdata(recvBuffer, recvSize);
 
         for (size_t pos = 0; pos < recvSize; ++pos) {
@@ -763,7 +764,7 @@ u_result RPlidarDriverSerialImpl::_waitCapsuledNode(rplidar_response_capsule_mea
                 if (recvChecksum == checksum)
                 {
                     // only consider vaild if the checksum matches...
-                    if (node.start_angle_sync_q6 & RPLIDAR_RESP_MEASUREMENT_EXP_SYNCBIT) 
+                    if (node.start_angle_sync_q6 & RPLIDAR_RESP_MEASUREMENT_EXP_SYNCBIT)
                     {
                         // this is the first capsule frame in logic, discard the previous cached data...
                         _is_previous_capsuledataRdy = false;
@@ -835,15 +836,15 @@ u_result RPlidarDriverSerialImpl::_waitResponseHeader(rplidar_ans_header_t * hea
     while ((waitTime=getms() - startTs) <= timeout) {
         size_t remainSize = sizeof(rplidar_ans_header_t) - recvPos;
         size_t recvSize;
-        
+
         int ans = _rxtx->waitfordata(remainSize, timeout - waitTime, &recvSize);
-        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR) 
+        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR)
             return RESULT_OPERATION_FAIL;
         else if (ans == rp::hal::serial_rxtx::ANS_TIMEOUT)
             return RESULT_OPERATION_TIMEOUT;
-        
+
         if(recvSize > remainSize) recvSize = remainSize;
-        
+
         _rxtx->recvdata(recvBuffer, recvSize);
 
         for (size_t pos = 0; pos < recvSize; ++pos) {
@@ -853,7 +854,7 @@ u_result RPlidarDriverSerialImpl::_waitResponseHeader(rplidar_ans_header_t * hea
                 if (currentByte != RPLIDAR_ANS_SYNC_BYTE1) {
                    continue;
                 }
-                
+
                 break;
             case 1:
                 if (currentByte != RPLIDAR_ANS_SYNC_BYTE2) {
@@ -882,11 +883,11 @@ void RPlidarDriverSerialImpl::_disableDataGrabbing()
 }
 
 u_result RPlidarDriverSerialImpl::getSampleDuration_uS(rplidar_response_sample_rate_t & rateInfo, _u32 timeout)
-{  
+{
     if (!isConnected()) return RESULT_OPERATION_FAIL;
-    
+
     _disableDataGrabbing();
-    
+
     rplidar_response_device_info_t devinfo;
     // 1. fetch the device version first...
     u_result ans = getDeviceInfo(devinfo, timeout);
@@ -935,9 +936,9 @@ u_result RPlidarDriverSerialImpl::checkMotorCtrlSupport(bool & support, _u32 tim
 {
     u_result  ans;
     support = false;
-    
+
     if (!isConnected()) return RESULT_OPERATION_FAIL;
-    
+
     _disableDataGrabbing();
 
     {
@@ -954,7 +955,7 @@ u_result RPlidarDriverSerialImpl::checkMotorCtrlSupport(bool & support, _u32 tim
         if (IS_FAIL(ans = _waitResponseHeader(&response_header, timeout))) {
             return ans;
         }
-        
+
         // verify whether we got a correct header
         if (response_header.type != RPLIDAR_ANS_TYPE_ACC_BOARD_FLAG) {
             return RESULT_INVALID_DATA;

--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -58,10 +58,10 @@ RPlidarDriver * RPlidarDriver::CreateDriver(_u32 drivertype)
 }
 
 
-void RPlidarDriver::DisposeDriver(RPlidarDriver * drv)
+void RPlidarDriver::DisposeDriver(RPlidarDriver ** drv)
 {
-    delete drv;
-    drv = NULL;
+    delete *drv;
+    *drv = NULL;
 }
 
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -139,9 +139,9 @@ bool checkRPLIDARHealth(RPlidarDriver * drv)
     rplidar_response_device_health_t healthinfo;
 
     op_result = drv->getHealth(healthinfo);
-    if (IS_OK(op_result)) { 
+    if (IS_OK(op_result)) {
         printf("RPLidar health status : %d\n", healthinfo.status);
-        
+
         if (healthinfo.status == RPLIDAR_STATUS_ERROR) {
             fprintf(stderr, "Error, rplidar internal error detected."
                             "Please reboot the device to retry.\n");
@@ -151,7 +151,7 @@ bool checkRPLIDARHealth(RPlidarDriver * drv)
         }
 
     } else {
-        fprintf(stderr, "Error, cannot retrieve rplidar health code: %x\n", 
+        fprintf(stderr, "Error, cannot retrieve rplidar health code: %x\n",
                         op_result);
         return false;
     }
@@ -192,8 +192,8 @@ int main(int argc, char * argv[]) {
     ros::NodeHandle nh;
     ros::Publisher scan_pub = nh.advertise<sensor_msgs::LaserScan>("scan", 1000);
     ros::NodeHandle nh_private("~");
-    nh_private.param<std::string>("serial_port", serial_port, "/dev/ttyUSB0"); 
-    nh_private.param<int>("serial_baudrate", serial_baudrate, 115200); 
+    nh_private.param<std::string>("serial_port", serial_port, "/dev/ttyUSB0");
+    nh_private.param<int>("serial_baudrate", serial_baudrate, 115200);
     nh_private.param<std::string>("frame_id", frame_id, "laser_frame");
     nh_private.param<bool>("inverted", inverted, false);
     nh_private.param<bool>("angle_compensate", angle_compensate, true);
@@ -205,7 +205,7 @@ int main(int argc, char * argv[]) {
 
     // create the driver instance
     drv = RPlidarDriver::CreateDriver(RPlidarDriver::DRIVER_TYPE_SERIALPORT);
-    
+
     if (!drv) {
         fprintf(stderr, "Create Driver fail, exit\n");
         return -2;
@@ -272,7 +272,7 @@ int main(int argc, char * argv[]) {
                             }
                         }
                     }
-  
+
                     publish_scan(&scan_pub, angle_compensate_nodes, angle_compensate_nodes_count,
                              start_scan_time, scan_duration, inverted,
                              angle_min, angle_max,

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -215,7 +215,7 @@ int main(int argc, char * argv[]) {
     if (IS_FAIL(drv->connect(serial_port.c_str(), (_u32)serial_baudrate))) {
         fprintf(stderr, "Error, cannot bind to the specified serial port %s.\n"
             , serial_port.c_str());
-        RPlidarDriver::DisposeDriver(drv);
+        RPlidarDriver::DisposeDriver(&drv);
         return -1;
     }
 
@@ -226,7 +226,7 @@ int main(int argc, char * argv[]) {
 
     // check health...
     if (!checkRPLIDARHealth(drv)) {
-        RPlidarDriver::DisposeDriver(drv);
+        RPlidarDriver::DisposeDriver(&drv);
         return -1;
     }
 
@@ -313,6 +313,6 @@ int main(int argc, char * argv[]) {
     // done!
     drv->stop();
     drv->stopMotor();
-    RPlidarDriver::DisposeDriver(drv);
+    RPlidarDriver::DisposeDriver(&drv);
     return 0;
 }


### PR DESCRIPTION
Sets driver pointer to NULL in `disposeDriver` after calling `delete`.
