### PR TITLE
multiple calling RPlidarDriverSerialImp::stop will cause Segmentation Fault

### DIFF
--- a/sdk/src/arch/linux/thread.hpp
+++ b/sdk/src/arch/linux/thread.hpp
@@ -131,6 +131,7 @@ u_result Thread::join(unsigned long timeout)
     if (!this->_handle) return RESULT_OK;
     
     pthread_join((pthread_t)(this->_handle), NULL);
+    this->_handle = 0;
     return RESULT_OK;
 }
 


### PR DESCRIPTION
multiple calling RPlidarDriverSerialImp::stop will cause Segmentation Fault that because of multiple calling pthread_join to a thread.